### PR TITLE
feat: complaint management system + UI typography fixes

### DIFF
--- a/srms-customer/app/(customer)/profile/page.tsx
+++ b/srms-customer/app/(customer)/profile/page.tsx
@@ -131,11 +131,11 @@ export default function ProfilePage() {
   return (
     <div className="min-h-screen bg-neutral-50">
       <Container>
-        <div className="py-8 md:py-12">
-          <div className="flex items-center justify-between mb-8">
+        <div className="py-6">
+          <div className="flex items-center justify-between mb-5">
             <div>
-              <h1 className="mb-2">My Profile</h1>
-              <p className="text-neutral-600">
+              <p className="text-lg font-semibold text-neutral-900 mb-0.5">My Profile</p>
+              <p className="text-sm text-neutral-500">
                 Manage your account information
               </p>
             </div>
@@ -160,9 +160,9 @@ export default function ProfilePage() {
                 <div className="h-24 w-24 rounded-full bg-primary-100 flex items-center justify-center mb-4">
                   <User className="h-12 w-12 text-primary-600" />
                 </div>
-                <h3 className="mb-1">
+                <p className="text-base font-semibold text-neutral-900 mb-1">
                   {profile.firstName} {profile.lastName}
-                </h3>
+                </p>
                 <p className="text-sm text-neutral-500 mb-4">{profile.email}</p>
 
                 {(profile as UserProfile & { createdAt?: string }).createdAt && (
@@ -179,7 +179,7 @@ export default function ProfilePage() {
             {/* Profile Details Card */}
             <Card className="md:col-span-2">
               <div className="p-6">
-                <h3 className="mb-6">Personal Information</h3>
+                <p className="text-sm font-semibold text-neutral-500 uppercase tracking-wider mb-4">Personal Information</p>
 
                 {editing ? (
                   <form onSubmit={handleSubmit} className="space-y-4">

--- a/srms-customer/app/(customer)/services/[id]/page.tsx
+++ b/srms-customer/app/(customer)/services/[id]/page.tsx
@@ -191,7 +191,7 @@ export default function ServiceDetailsPage() {
               </div>
 
               {/* Service Name */}
-              <h1 className="text-3xl md:text-4xl mb-3">{service.name}</h1>
+              <p className="text-xl font-bold text-neutral-900 mb-3">{service.name}</p>
 
               {/* Rating */}
               {service.rating && (
@@ -229,7 +229,7 @@ export default function ServiceDetailsPage() {
                 <div className="flex items-end justify-between mb-4">
                   <div>
                     <p className="text-xs text-neutral-500 mb-1">Starting at</p>
-                    <p className="text-3xl font-bold text-primary-600">
+                    <p className="text-2xl font-bold text-primary-600">
                       {formatPrice(service.basePrice)}
                     </p>
                   </div>
@@ -252,9 +252,9 @@ export default function ServiceDetailsPage() {
       </div>
 
       {/* Key Features Section */}
-      <div className="bg-white py-12 lg:py-16">
+      <div className="bg-white py-8 lg:py-10">
         <Container>
-          <h2 className="text-center mb-10">Why Choose Us</h2>
+          <p className="text-base font-semibold text-neutral-900 text-center mb-8">Why Choose Us</p>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {keyFeatures.map((feature, index) => (
               <Card
@@ -262,10 +262,10 @@ export default function ServiceDetailsPage() {
                 padding="lg"
                 className="text-center hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1"
               >
-                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary-100 text-primary-600 mb-4">
-                  <feature.icon className="h-8 w-8" />
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-primary-100 text-primary-600 mb-4">
+                  <feature.icon className="h-6 w-6" />
                 </div>
-                <h5 className="mb-2">{feature.title}</h5>
+                <p className="text-sm font-semibold text-neutral-900 mb-2">{feature.title}</p>
                 <p className="text-sm text-neutral-600">{feature.description}</p>
               </Card>
             ))}
@@ -274,10 +274,10 @@ export default function ServiceDetailsPage() {
       </div>
 
       {/* What's Included Section */}
-      <div className="bg-neutral-50 py-12 lg:py-16">
+      <div className="bg-neutral-50 py-8 lg:py-10">
         <Container>
           <div className="max-w-4xl mx-auto">
-            <h2 className="text-center mb-10">What's Included</h2>
+            <p className="text-base font-semibold text-neutral-900 text-center mb-6">What's Included</p>
             <Card padding="lg" variant="elevated">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {benefits.map((benefit, index) => (
@@ -293,9 +293,9 @@ export default function ServiceDetailsPage() {
       </div>
 
       {/* How It Works Section */}
-      <div className="bg-white py-12 lg:py-16">
+      <div className="bg-white py-8 lg:py-10">
         <Container>
-          <h2 className="text-center mb-10">How It Works</h2>
+          <p className="text-base font-semibold text-neutral-900 text-center mb-8">How It Works</p>
           <div className="max-w-5xl mx-auto">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {[
@@ -319,10 +319,10 @@ export default function ServiceDetailsPage() {
                 },
               ].map((step, index) => (
                 <div key={index} className="text-center relative">
-                  <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-br from-primary-500 to-accent-500 text-white text-3xl font-bold mb-4 shadow-lg">
+                  <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-br from-primary-500 to-accent-500 text-white text-lg font-bold mb-4 shadow-lg">
                     {step.step}
                   </div>
-                  <h4 className="mb-2">{step.title}</h4>
+                  <p className="text-sm font-semibold text-neutral-900 mb-1">{step.title}</p>
                   <p className="text-neutral-600">{step.description}</p>
                   {index < 2 && (
                     <ChevronRight className="hidden md:block absolute top-8 -right-4 h-8 w-8 text-neutral-300" />
@@ -336,10 +336,10 @@ export default function ServiceDetailsPage() {
 
       {/* Related Services Section */}
       {relatedServices.length > 0 && (
-        <div className="bg-neutral-50 py-12 lg:py-16">
+        <div className="bg-neutral-50 py-8 lg:py-10">
           <Container>
             <div className="flex items-center justify-between mb-8">
-              <h2>Related Services</h2>
+              <p className="text-base font-semibold text-neutral-900">Related Services</p>
               <Link
                 href={`/services?category=${service.category.slug || service.category.id}`}
                 className="text-primary-600 hover:text-primary-700 font-medium flex items-center gap-1"
@@ -366,14 +366,14 @@ export default function ServiceDetailsPage() {
                       </div>
                     )}
                     <div className="p-4">
-                      <h6 className="mb-2 line-clamp-2">
+                      <p className="text-sm font-medium text-neutral-800 mb-1.5 line-clamp-2">
                         {relatedService.name}
-                      </h6>
+                      </p>
                       <p className="text-sm text-neutral-600 mb-3 line-clamp-2">
                         {relatedService.description}
                       </p>
                       <div className="flex items-center justify-between">
-                        <span className="text-lg font-bold text-primary-600">
+                        <span className="text-sm font-bold text-primary-600">
                           {formatPrice(relatedService.basePrice)}
                         </span>
                         {relatedService.rating && (

--- a/srms-customer/app/(customer)/services/page.tsx
+++ b/srms-customer/app/(customer)/services/page.tsx
@@ -107,9 +107,9 @@ export default function ServicesPage() {
     <div className="min-h-screen bg-neutral-50">
       <Container>
         {/* Header */}
-        <div className="py-8 md:py-12">
-          <h1 className="mb-4">Our Services</h1>
-          <p className="text-lg text-neutral-600">
+        <div className="py-6">
+          <p className="text-lg font-semibold text-neutral-900 mb-1">Our Services</p>
+          <p className="text-sm text-neutral-500">
             Professional home services delivered with care and quality
           </p>
         </div>
@@ -129,13 +129,13 @@ export default function ServicesPage() {
           </div>
 
           {/* Category Filter */}
-          <div className="flex flex-wrap gap-2">
+          <div className="flex gap-1.5 flex-wrap bg-white border border-neutral-200 p-1 rounded-lg w-fit">
             <button
               onClick={() => handleCategoryChange("all")}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+              className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
                 selectedCategory === "all"
-                  ? "bg-primary-600 text-white"
-                  : "bg-white text-neutral-700 hover:bg-neutral-100"
+                  ? "bg-neutral-900 text-white"
+                  : "text-neutral-500 hover:text-neutral-800"
               }`}
             >
               All Services
@@ -144,10 +144,10 @@ export default function ServicesPage() {
               <button
                 key={category.id}
                 onClick={() => handleCategoryChange(category.id)}
-                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
                   selectedCategory === category.id
-                    ? "bg-primary-600 text-white"
-                    : "bg-white text-neutral-700 hover:bg-neutral-100"
+                    ? "bg-neutral-900 text-white"
+                    : "text-neutral-500 hover:text-neutral-800"
                 }`}
               >
                 {category.name}
@@ -203,7 +203,7 @@ export default function ServicesPage() {
                     </div>
                   )}
                   <div className="p-5">
-                    <h4 className="mb-2 font-semibold">{service.name}</h4>
+                    <p className="text-sm font-semibold text-neutral-900 mb-1.5">{service.name}</p>
                     <p className="text-sm text-neutral-600 mb-4 line-clamp-2">
                       {service.description}
                     </p>
@@ -225,7 +225,7 @@ export default function ServicesPage() {
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-sm text-neutral-500">Starting at</p>
-                        <p className="text-xl font-bold text-primary-600">
+                        <p className="text-lg font-bold text-primary-600">
                           {formatPrice(service.basePrice)}
                         </p>
                       </div>


### PR DESCRIPTION
## Summary

- **Complaint Management System** — full end-to-end flow: customer raises complaint on closed service requests → admin reviews in Filament panel → assigns engineer → engineer resolves via OTP confirmation → customer verifies → complaint closed
- **Notification hashids fix** — 6 notification classes were storing raw integer IDs instead of hashids; fixed across all service request and complaint notifications so in-app links navigate correctly
- **Clear all notifications** — added `DELETE /api/notifications` endpoint; wired up in customer bell dropdown and engineer notifications page
- **UI typography overhaul** — replaced all bare heading tags (`h1`–`h6`) with explicit `text-*` classes across complaints, my-requests, services, service detail, and profile pages; global CSS was inflating headings to 3xl–5xl

## Detailed Changes

### Backend
- New `complaints` table, `Complaint` model, `ComplaintPolicy`, `ComplaintController` (7 routes)
- `ComplaintStatus` enum: `pending`, `in_progress`, `closed`
- OTP type `complaint_resolution` for engineer→customer resolution flow
- Filament resource with inline admin actions (assign engineer, close with note)
- Complaint notifications: `ComplaintCreated`, `ComplaintAssigned`, `ComplaintOtpNotification`, `ComplaintClosed`
- `SendComplaintResolutionOtpJob` queued job + `ComplaintResolutionOtpMail`
- Fixed hashids encoding in 6 existing notification classes
- `NotificationController::clearAll()` — `DELETE /api/notifications`

### Customer App (srms-customer)
- `/complaints` — list with filter tabs
- `/complaints/new` — 2-step wizard (select closed SR → describe + upload images)
- `/complaints/[id]` — detail with progress tracker, evidence lightbox, admin note, sidebar
- Notification bell: routes to complaint/SR on click, added "Clear all"
- Typography fixes: services list, service detail, profile, my-requests pages

### Engineer App (srms-engineer)
- `/complaints` — assigned complaints list
- `/complaints/[id]` — detail with OTP resolution panel
- Sidebar: Complaints nav item added
- Notifications page: "Mark all read" + "Clear all" text links
- OTP input font size reduced

## Test plan
- [ ] Customer raises complaint on a closed service request with images
- [ ] Admin sees notification, opens Filament `/admin/complaints`, marks in-progress and assigns engineer
- [ ] Engineer sees notification, navigates to `/complaints/[id]`, sends resolution OTP
- [ ] Customer receives OTP in notification, shares with engineer
- [ ] Engineer enters OTP → complaint closes → both parties notified
- [ ] Admin can also close directly with a note
- [ ] Notification links navigate to correct complaint/SR pages
- [ ] Clear all notifications works on both apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)