### PR TITLE
feat: contact enquiry — store submissions and Filament admin view

### DIFF
--- a/srms-backend/app/Filament/Resources/ContactEnquiry/ContactEnquiryResource.php
+++ b/srms-backend/app/Filament/Resources/ContactEnquiry/ContactEnquiryResource.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Resources\ContactEnquiry;
+
+use App\Filament\Resources\ContactEnquiry\Pages\ListContactEnquiries;
+use App\Filament\Resources\ContactEnquiry\Pages\ViewContactEnquiry;
+use App\Filament\Resources\ContactEnquiry\Schemas\ContactEnquiryInfolist;
+use App\Filament\Resources\ContactEnquiry\Tables\ContactEnquiriesTable;
+use App\Models\ContactEnquiry;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class ContactEnquiryResource extends Resource
+{
+    protected static ?string $model = ContactEnquiry::class;
+
+    protected static ?int $navigationSort = 5;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-envelope';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Support';
+
+    protected static ?string $recordTitleAttribute = 'enquiry_number';
+
+    protected static ?string $navigationLabel = 'Contact Enquiries';
+
+    protected static ?string $pluralModelLabel = 'Contact Enquiries';
+
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::where('status', 'new')->count() ?: null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'danger';
+    }
+
+    public static function getGloballySearchableAttributes(): array
+    {
+        return ['enquiry_number', 'name', 'email', 'subject'];
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return ContactEnquiryInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ContactEnquiriesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListContactEnquiries::route('/'),
+            'view'  => ViewContactEnquiry::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    {
+        return false;
+    }
+}

--- a/srms-backend/app/Filament/Resources/ContactEnquiry/Pages/ListContactEnquiries.php
+++ b/srms-backend/app/Filament/Resources/ContactEnquiry/Pages/ListContactEnquiries.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ContactEnquiry\Pages;
+
+use App\Filament\Resources\ContactEnquiry\ContactEnquiryResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListContactEnquiries extends ListRecords
+{
+    protected static string $resource = ContactEnquiryResource::class;
+}

--- a/srms-backend/app/Filament/Resources/ContactEnquiry/Pages/ViewContactEnquiry.php
+++ b/srms-backend/app/Filament/Resources/ContactEnquiry/Pages/ViewContactEnquiry.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Resources\ContactEnquiry\Pages;
+
+use App\Filament\Resources\ContactEnquiry\ContactEnquiryResource;
+use App\Models\ContactEnquiry;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewContactEnquiry extends ViewRecord
+{
+    protected static string $resource = ContactEnquiryResource::class;
+
+    public function mount(int|string $record): void
+    {
+        parent::mount($record);
+
+        // Auto-mark as read when opened
+        /** @var ContactEnquiry $enquiry */
+        $enquiry = $this->record;
+        if ($enquiry->status === 'new') {
+            $enquiry->update(['status' => 'read']);
+        }
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('mark_replied')
+                ->label('Mark as Replied')
+                ->icon('heroicon-o-check-circle')
+                ->color('success')
+                ->visible(fn () => $this->record->status !== 'replied')
+                ->form([
+                    \Filament\Forms\Components\Textarea::make('admin_note')
+                        ->label('Reply / Internal Note')
+                        ->rows(4)
+                        ->placeholder('Optionally record how this was handled or what was replied...'),
+                ])
+                ->action(function (array $data) {
+                    $this->record->update([
+                        'status'     => 'replied',
+                        'admin_note' => $data['admin_note'] ?: $this->record->admin_note,
+                    ]);
+
+                    Notification::make()
+                        ->title('Enquiry marked as replied.')
+                        ->success()
+                        ->send();
+
+                    $this->refreshFormData(['status', 'admin_note']);
+                })
+                ->requiresConfirmation(false),
+
+            Action::make('mark_new')
+                ->label('Mark as New')
+                ->icon('heroicon-o-arrow-uturn-left')
+                ->color('gray')
+                ->visible(fn () => $this->record->status !== 'new')
+                ->action(function () {
+                    $this->record->update(['status' => 'new']);
+
+                    Notification::make()
+                        ->title('Enquiry marked as new.')
+                        ->success()
+                        ->send();
+
+                    $this->refreshFormData(['status']);
+                }),
+        ];
+    }
+}

--- a/srms-backend/app/Filament/Resources/ContactEnquiry/Schemas/ContactEnquiryInfolist.php
+++ b/srms-backend/app/Filament/Resources/ContactEnquiry/Schemas/ContactEnquiryInfolist.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Filament\Resources\ContactEnquiry\Schemas;
+
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class ContactEnquiryInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                Section::make('Enquiry Details')
+                    ->schema([
+                        TextEntry::make('enquiry_number')
+                            ->label('Enquiry #')
+                            ->weight('bold')
+                            ->copyable(),
+                        TextEntry::make('status')
+                            ->badge()
+                            ->formatStateUsing(fn (string $state): string => match ($state) {
+                                'new'     => 'New',
+                                'read'    => 'Read',
+                                'replied' => 'Replied',
+                                default   => ucfirst($state),
+                            })
+                            ->color(fn (string $state): string => match ($state) {
+                                'new'     => 'danger',
+                                'read'    => 'warning',
+                                'replied' => 'Replied',
+                                default   => 'gray',
+                            }),
+                        TextEntry::make('created_at')
+                            ->label('Submitted At')
+                            ->dateTime('F j, Y g:i A'),
+                        TextEntry::make('subject')
+                            ->columnSpanFull(),
+                        TextEntry::make('message')
+                            ->columnSpanFull()
+                            ->prose(),
+                    ])
+                    ->columns(2)
+                    ->columnSpanFull(),
+
+                Section::make('Contact Information')
+                    ->schema([
+                        TextEntry::make('name')
+                            ->weight('bold'),
+                        TextEntry::make('email')
+                            ->copyable()
+                            ->color('primary'),
+                        TextEntry::make('phone')
+                            ->placeholder('Not provided')
+                            ->copyable(),
+                    ])
+                    ->columns(3)
+                    ->columnSpanFull(),
+
+                Section::make('Admin Note')
+                    ->schema([
+                        TextEntry::make('admin_note')
+                            ->label('')
+                            ->columnSpanFull()
+                            ->placeholder('No note added yet.')
+                            ->prose(),
+                    ])
+                    ->columnSpanFull()
+                    ->collapsible(),
+            ]);
+    }
+}

--- a/srms-backend/app/Filament/Resources/ContactEnquiry/Tables/ContactEnquiriesTable.php
+++ b/srms-backend/app/Filament/Resources/ContactEnquiry/Tables/ContactEnquiriesTable.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Filament\Resources\ContactEnquiry\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ContactEnquiriesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('enquiry_number')
+                    ->label('Enquiry #')
+                    ->searchable()
+                    ->sortable()
+                    ->weight('bold')
+                    ->copyable(),
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->searchable()
+                    ->copyable()
+                    ->color('primary'),
+                TextColumn::make('subject')
+                    ->searchable()
+                    ->limit(40),
+                TextColumn::make('status')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'new'     => 'New',
+                        'read'    => 'Read',
+                        'replied' => 'Replied',
+                        default   => ucfirst($state),
+                    })
+                    ->color(fn (string $state): string => match ($state) {
+                        'new'     => 'danger',
+                        'read'    => 'warning',
+                        'replied' => 'success',
+                        default   => 'gray',
+                    })
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label('Submitted At')
+                    ->dateTime('M j, Y g:i A')
+                    ->sortable()
+                    ->since(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options([
+                        'new'     => 'New',
+                        'read'    => 'Read',
+                        'replied' => 'Replied',
+                    ]),
+                Filter::make('created_at')
+                    ->form([
+                        DatePicker::make('created_from')->label('From'),
+                        DatePicker::make('created_until')->label('Until'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when($data['created_from'], fn ($q, $d) => $q->whereDate('created_at', '>=', $d))
+                        ->when($data['created_until'], fn ($q, $d) => $q->whereDate('created_at', '<=', $d))
+                    ),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/srms-backend/app/Http/Controllers/Api/ContactEnquiryController.php
+++ b/srms-backend/app/Http/Controllers/Api/ContactEnquiryController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreContactEnquiryRequest;
+use App\Models\ContactEnquiry;
+use App\Models\User;
+use App\Notifications\ContactEnquiryReceived;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Notification;
+
+class ContactEnquiryController extends Controller
+{
+    public function store(StoreContactEnquiryRequest $request): JsonResponse
+    {
+        $enquiry = ContactEnquiry::create([
+            'enquiry_number' => ContactEnquiry::generateEnquiryNumber(),
+            'name'           => $request->input('name'),
+            'email'          => $request->input('email'),
+            'phone'          => $request->input('phone'),
+            'subject'        => $request->input('subject'),
+            'message'        => $request->input('message'),
+            'status'         => 'new',
+        ]);
+
+        $admins = User::whereHas('role', fn ($q) => $q->where('name', 'Admin'))->get();
+        Notification::send($admins, new ContactEnquiryReceived($enquiry));
+
+        return response()->json([
+            'message' => 'Your enquiry has been submitted. We will get back to you shortly.',
+        ], 201);
+    }
+}

--- a/srms-backend/app/Http/Requests/StoreContactEnquiryRequest.php
+++ b/srms-backend/app/Http/Requests/StoreContactEnquiryRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreContactEnquiryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'    => ['required', 'string', 'max:255'],
+            'email'   => ['required', 'email', 'max:255'],
+            'phone'   => ['nullable', 'string', 'max:30'],
+            'subject' => ['required', 'string', 'max:255'],
+            'message' => ['required', 'string', 'min:10', 'max:5000'],
+        ];
+    }
+}

--- a/srms-backend/app/Models/ContactEnquiry.php
+++ b/srms-backend/app/Models/ContactEnquiry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContactEnquiry extends Model
+{
+    protected $fillable = [
+        'enquiry_number',
+        'name',
+        'email',
+        'phone',
+        'subject',
+        'message',
+        'status',
+        'admin_note',
+    ];
+
+    public static function generateEnquiryNumber(): string
+    {
+        $prefix = 'ENQ';
+        $date = now()->format('Ymd');
+        $last = static::whereDate('created_at', today())
+            ->orderByDesc('id')
+            ->value('enquiry_number');
+
+        $sequence = 1;
+        if ($last) {
+            $parts = explode('-', $last);
+            $sequence = (int) end($parts) + 1;
+        }
+
+        return $prefix . '-' . $date . '-' . str_pad((string) $sequence, 4, '0', STR_PAD_LEFT);
+    }
+}

--- a/srms-backend/app/Notifications/ContactEnquiryReceived.php
+++ b/srms-backend/app/Notifications/ContactEnquiryReceived.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\ContactEnquiry;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class ContactEnquiryReceived extends Notification
+{
+    use Queueable;
+
+    public function __construct(public ContactEnquiry $enquiry) {}
+
+    public function via(mixed $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(mixed $notifiable): array
+    {
+        return [
+            'format'         => 'filament',
+            'title'          => 'New Contact Enquiry',
+            'body'           => "New enquiry from {$this->enquiry->name} ({$this->enquiry->email}): {$this->enquiry->subject}",
+            'enquiry_id'     => $this->enquiry->id,
+            'enquiry_number' => $this->enquiry->enquiry_number,
+            'icon'           => 'heroicon-o-envelope',
+            'color'          => 'info',
+            'url'            => '/admin/contact-enquiries/' . $this->enquiry->id,
+        ];
+    }
+}

--- a/srms-backend/database/migrations/2026_04_22_000001_create_contact_enquiries_table.php
+++ b/srms-backend/database/migrations/2026_04_22_000001_create_contact_enquiries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('contact_enquiries', function (Blueprint $table) {
+            $table->id();
+            $table->string('enquiry_number')->unique();
+            $table->string('name');
+            $table->string('email');
+            $table->string('phone')->nullable();
+            $table->string('subject');
+            $table->text('message');
+            $table->string('status')->default('new'); // new, read, replied
+            $table->text('admin_note')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('contact_enquiries');
+    }
+};

--- a/srms-backend/routes/api.php
+++ b/srms-backend/routes/api.php
@@ -35,6 +35,10 @@ Route::prefix('auth')->group(function () {
     });
 });
 
+// Contact enquiry — public, no auth required
+Route::post('contact', [\App\Http\Controllers\Api\ContactEnquiryController::class, 'store'])
+    ->middleware('throttle:5,1');
+
 // Public routes - No authentication required
 Route::prefix('public')->group(function () {
     // Categories

--- a/srms-customer/app/(customer)/contact/page.tsx
+++ b/srms-customer/app/(customer)/contact/page.tsx
@@ -2,10 +2,12 @@
 
 import { useState } from "react";
 import { Mail, Phone, MapPin, Send, CheckCircle, Clock, HelpCircle } from "lucide-react";
+import { toast } from "sonner";
 import Container from "@/components/layout/Container";
 import Card from "@/components/common/Card";
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
+import { apiClient } from "@/lib/api/client";
 
 export default function ContactPage() {
   const [formData, setFormData] = useState({
@@ -17,28 +19,25 @@ export default function ContactPage() {
   });
   const [submitted, setSubmitted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+    setError(null);
 
-    // Simulate API call
-    setTimeout(() => {
-      setLoading(false);
+    try {
+      await apiClient.post("/contact", formData);
+
       setSubmitted(true);
-
-      // Reset form
-      setFormData({
-        name: "",
-        email: "",
-        phone: "",
-        subject: "",
-        message: "",
-      });
-
-      // Reset success message after 5 seconds
-      setTimeout(() => setSubmitted(false), 5000);
-    }, 1000);
+      setFormData({ name: "", email: "", phone: "", subject: "", message: "" });
+      toast.success("Message sent! We'll get back to you shortly.");
+      setTimeout(() => setSubmitted(false), 8000);
+    } catch {
+      setError("Failed to send your message. Please try again.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleChange = (
@@ -197,6 +196,12 @@ export default function ContactPage() {
                         Thank you for contacting us. We'll get back to you soon.
                       </p>
                     </div>
+                  </div>
+                )}
+
+                {error && (
+                  <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+                    <p className="text-sm text-red-700">{error}</p>
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary

- **Backend**: Public `POST /api/contact` endpoint stores enquiries in a new `contact_enquiries` table and fires a `ContactEnquiryReceived` database notification to all admins
- **Filament**: New "Contact Enquiries" resource under the Support nav group — lists all submissions with status badges, auto-marks as read when opened, admin can mark as Replied with an optional note
- **Customer app**: Contact page at `/contact` now submits to the real API instead of simulating a fake delay

## Changes

| Area | Files |
|------|-------|
| Migration | `create_contact_enquiries_table` |
| Model | `ContactEnquiry` with `generateEnquiryNumber()` |
| API | `ContactEnquiryController`, `StoreContactEnquiryRequest`, route added to `api.php` |
| Notification | `ContactEnquiryReceived` (database, sent to all admins) |
| Filament | `ContactEnquiryResource`, table, infolist, list/view pages |
| Frontend | `srms-customer/contact/page.tsx` — real API call, toast on success, inline error on failure |

## Behaviour

- Enquiry numbers follow the format `ENQ-YYYYMMDD-0001`
- Status flow: `new` → auto `read` on admin open → `replied` via header action
- Nav badge shows count of unread (`new`) enquiries in red
- Admin can add an internal note when marking as replied
- Route is throttled at 5 requests/min, no authentication required

## Test plan

- [ ] Submit the contact form at `http://localhost:3000/contact` — confirm 201 response and toast
- [ ] Check admin panel at `http://localhost:8000/admin/contact-enquiry/contact-enquiries` — record appears with status "New" and red badge
- [ ] Open the record — status should auto-change to "Read"
- [ ] Click "Mark as Replied" with a note — status changes to "Replied" (green)
- [ ] Admin receives an in-app notification that redirects to the enquiry record

🤖 Generated with [Claude Code](https://claude.com/claude-code)